### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "rust"
+run = "cargo run"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# rust-cargo-template
-Template for Rust Project
+# Git Explore
+[![Run on Repl.it](https://repl.it/badge/github/itsrainingmani/gitexplore)](https://repl.it/github/itsrainingmani/gitexplore)
+
+Rust CLI that will allow you to find git commands with free text search


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).